### PR TITLE
Add installation instructions for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ chmod +x ./kind
 mv ./kind /some-dir-in-your-PATH/kind
 ```
 
+On Mac via Homebrew:
+
+```console
+brew install kind
+```
+
 On Windows:
 
 ```powershell


### PR DESCRIPTION
Kind has been added to homebrew-core via https://github.com/Homebrew/homebrew-core/pull/46886 so here I add the instruction to install it on MacOS via Homebrew.